### PR TITLE
Add `loader()` export support

### DIFF
--- a/src/core/core.tsx
+++ b/src/core/core.tsx
@@ -10,16 +10,6 @@ import { RequestVariables } from "@/requestVariables";
 import { getAlertMessages } from "@/services/alertMessages.service";
 import { useContext } from "preact/hooks";
 
-// let indexFunction: (children: VNode) => VNode = (children) => {
-//   return <div>{children}</div>;
-// };
-
-// let indexFunction: (children: VNode) => VNode | null = null;
-
-// export function setIndexComponent(func: (children: VNode) => VNode) {
-//   indexFunction = func;
-// }
-
 export async function setIndexHTML(filePath: string) {
   htmlParser.parse(filePath);
 }
@@ -27,46 +17,10 @@ export async function setIndexHTML(filePath: string) {
 export const AlertMessagesContext = createContext<AlertMessage[]>([]);
 export const RequestContext = createContext<Context | null>(null);
 
-function LoaderContextProvider({
-  data,
-  children,
-}: {
-  data: any;
-  children: VNode;
-}) {
-  return (
-    <LoaderContext.Provider value={data}>{children}</LoaderContext.Provider>
-  );
-}
-
-function AlertMessagesProvider({
-  data,
-  children,
-}: {
-  data: AlertMessage[];
-  children: VNode;
-}) {
-  return (
-    <AlertMessagesContext.Provider value={data}>
-      {children}
-    </AlertMessagesContext.Provider>
-  );
-}
-
-function RequestProvider({
-  data,
-  children,
-}: {
-  data: Context;
-  children: VNode;
-}) {
-  return (
-    <RequestContext.Provider value={data}>{children}</RequestContext.Provider>
-  );
-}
-
 export function applyContext(c: Context, component: VNode) {
-  return <RequestProvider data={c}>{component}</RequestProvider>;
+  return (
+    <RequestContext.Provider value={c}>{component}</RequestContext.Provider>
+  );
 }
 
 export function applyAlertMessages(
@@ -74,9 +28,9 @@ export function applyAlertMessages(
   component: VNode
 ) {
   return (
-    <AlertMessagesProvider data={alertMessages}>
+    <AlertMessagesContext.Provider value={alertMessages}>
       {component}
-    </AlertMessagesProvider>
+    </AlertMessagesContext.Provider>
   );
 }
 
@@ -130,11 +84,13 @@ export const LoaderContext = createContext<any | null>(null);
 
 export function applyLoaderContext<T>(loaderData: T, component: VNode) {
   return (
-    <LoaderContextProvider data={loaderData}>{component}</LoaderContextProvider>
+    <LoaderContext.Provider value={loaderData}>
+      {component}
+    </LoaderContext.Provider>
   );
 }
 
-export function useLoader<T extends () => Promise<any>>() {
+export function useLoaderData<T extends () => Promise<any>>() {
   const data = useContext(LoaderContext);
   if (data === null) {
     //throw new Error("useLoader must be used within a LoaderContext.Provider");

--- a/src/core/core.tsx
+++ b/src/core/core.tsx
@@ -93,7 +93,7 @@ export function applyLoaderContext<T>(loaderData: T, component: VNode) {
 export function useLoaderData<T extends () => Promise<any>>() {
   const data = useContext(LoaderContext);
   if (data === null) {
-    //throw new Error("useLoader must be used within a LoaderContext.Provider");
+    throw new Error("useLoader must be used within a LoaderContext.Provider");
   }
   return data as Awaited<ReturnType<T>>;
 }

--- a/src/core/core.tsx
+++ b/src/core/core.tsx
@@ -96,7 +96,6 @@ export async function renderComponent(
   );
 
   if (loader) {
-    console.log("applied loader");
     const loaderData = await loader();
     componentWithContext = applyLoaderContext(loaderData, componentWithContext);
   }
@@ -137,8 +136,6 @@ export function applyLoaderContext<T>(loaderData: T, component: VNode) {
 
 export function useLoader<T extends () => Promise<any>>() {
   const data = useContext(LoaderContext);
-  console.log(data);
-
   if (data === null) {
     //throw new Error("useLoader must be used within a LoaderContext.Provider");
   }

--- a/src/middleware/fileRouter.ts
+++ b/src/middleware/fileRouter.ts
@@ -31,7 +31,13 @@ async function importPageComponent(filePath: string): Promise<PageComponent> {
 
   let template = null;
   let loaderFunc = null;
+  let hasDefaultExport = false;
+
   for (const exportName in page) {
+    if (exportName == "default") {
+      hasDefaultExport = true;
+    }
+
     if (page.hasOwnProperty(exportName) && exportName == "loader") {
       loaderFunc = page[exportName];
       continue;
@@ -46,8 +52,14 @@ async function importPageComponent(filePath: string): Promise<PageComponent> {
     }
   }
 
+  if (!template && !hasDefaultExport) {
+    throw new Error(
+      `export named ${componentName} not found in ${filePath}. No default export found either`
+    );
+  }
+
   if (!template) {
-    throw new Error("No component found in file");
+    template = page.default;
   }
 
   return {

--- a/src/middleware/fileRouter.ts
+++ b/src/middleware/fileRouter.ts
@@ -1,7 +1,7 @@
 import { renderComponent } from "@/core";
 import { RequestVariables } from "@/requestVariables";
 import { MiddlewareHandler } from "hono";
-import { createElement } from "preact";
+import { FunctionComponent, createElement } from "preact";
 
 const router = new Bun.FileSystemRouter({
   style: "nextjs",
@@ -12,13 +12,48 @@ const router = new Bun.FileSystemRouter({
 
 let pageCache: Record<string, any> = {};
 
-async function fetchPageComponent(filePath: string) {
+type PageComponent = {
+  loader: <T>() => Promise<T>;
+  template: FunctionComponent;
+};
+
+async function importPageComponent(filePath: string): Promise<PageComponent> {
   if (pageCache[filePath]) {
     return pageCache[filePath];
   }
 
+  const componentName = filePath.split("/").pop()?.split(".")[0];
+  if (!componentName) {
+    throw new Error("No component name found in file path");
+  }
+
   const page = await import(filePath);
-  return page.default;
+
+  let template = null;
+  let loaderFunc = null;
+  for (const exportName in page) {
+    if (page.hasOwnProperty(exportName) && exportName == "loader") {
+      loaderFunc = page[exportName];
+      continue;
+    }
+
+    if (
+      page.hasOwnProperty(exportName) &&
+      exportName.toLowerCase() == componentName?.toLowerCase()
+    ) {
+      template = page[exportName];
+      continue;
+    }
+  }
+
+  if (!template) {
+    throw new Error("No component found in file");
+  }
+
+  return {
+    loader: loaderFunc,
+    template: template,
+  };
 }
 
 export const fileRouter = (): MiddlewareHandler<{
@@ -37,10 +72,9 @@ export const fileRouter = (): MiddlewareHandler<{
     };
 
     if (routeMatch) {
-      const pageComponent = await fetchPageComponent(routeMatch.filePath);
-
-      const element = createElement(pageComponent, {});
-      return renderComponent(c, element);
+      const pageComponent = await importPageComponent(routeMatch.filePath);
+      const element = createElement(pageComponent.template, {});
+      return renderComponent(c, element, pageComponent.loader);
     }
 
     return next();

--- a/src/pages/user/index.tsx
+++ b/src/pages/user/index.tsx
@@ -1,5 +1,4 @@
 import { Layout } from "@/components/Layout";
-import { Heading } from "@/components/core/Heading";
 import { useLoaderData } from "@/core";
 import { userRepo } from "@/database/models/user/user.repo.drizzle";
 

--- a/src/pages/user/index.tsx
+++ b/src/pages/user/index.tsx
@@ -1,23 +1,42 @@
 import { Layout } from "@/components/Layout";
-import { Button } from "@/components/core/Button";
-import { FormInput } from "@/components/core/FormInput";
 import { Heading } from "@/components/core/Heading";
+import { useLoader } from "@/core";
+import { userRepo } from "@/database/models/user/user.repo.drizzle";
 
-export default function CreateUser() {
+export async function loader() {
+  const users = await userRepo.listUsers();
+
+  return {
+    users,
+  };
+}
+
+export function Index() {
+  let data = useLoader<typeof loader>();
+
   return (
     <Layout>
-      <div class="flex items-center justify-center">
-        <Heading size="2xl">User Index</Heading>
-      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>Id</th>
+            <th>Username</th>
+            <th>Email</th>
+          </tr>
+        </thead>
 
-      <div class="flex flex-col items-center justify-center">
-        <form action="/user/create" method="POST">
-          <FormInput label="Email" name="email" />
-          <FormInput label="Password" name="password" type="password" />
-
-          <Button className="mt-2">Create User</Button>
-        </form>
-      </div>
+        <tbody>
+          {data.users.map((user) => {
+            return (
+              <tr>
+                <td>{user.id}</td>
+                <td>{user.username}</td>
+                <td>{user.email}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
     </Layout>
   );
 }

--- a/src/pages/user/index.tsx
+++ b/src/pages/user/index.tsx
@@ -1,6 +1,6 @@
 import { Layout } from "@/components/Layout";
 import { Heading } from "@/components/core/Heading";
-import { useLoader } from "@/core";
+import { useLoaderData } from "@/core";
 import { userRepo } from "@/database/models/user/user.repo.drizzle";
 
 export async function loader() {
@@ -12,7 +12,7 @@ export async function loader() {
 }
 
 export function Index() {
-  let data = useLoader<typeof loader>();
+  let data = useLoaderData<typeof loader>();
 
   return (
     <Layout>


### PR DESCRIPTION
Added support for loading data async for page components via `loader()` function. 

The file router will automatically call this `loader()` function and await it before rendering out the JSX template.  
```ts
import { Layout } from "@/components/Layout";
import { useLoaderData } from "@/core";
import { userRepo } from "@/database/models/user/user.repo.drizzle";

export async function loader() {
  const users = await userRepo.listUsers();

  return {
    users,
  };
}

export function Index() {
  let data = useLoaderData<typeof loader>();

  return (
    <Layout>
      <table>
        <thead>
          <tr>
            <th>Id</th>
            <th>Username</th>
            <th>Email</th>
          </tr>
        </thead>

        <tbody>
          {data.users.map((user) => {
            return (
              <tr>
                <td>{user.id}</td>
                <td>{user.username}</td>
                <td>{user.email}</td>
              </tr>
            );
          })}
        </tbody>
      </table>
    </Layout>
  );
}

```